### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           cd "${{ env.repo_dir }}"
           sudo apt-get -y install imagemagick
-          convert "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
-          convert "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
+          magick "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
+          magick "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
 
       - name: Copy files to build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           cd "${{ env.repo_dir }}"
           sudo apt-get -y install imagemagick
-          magick "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
-          magick "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
+          convert "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
+          convert "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
 
       - name: Copy files to build
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: "${{ env.repo_dir }}"
 
       - name: Compile LaTeX documents
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           working_directory: "${{ env.repo_dir }}/example"
           root_file: "${{ env.example_file }}.tex"
@@ -53,7 +53,7 @@ jobs:
 
       # upload workflow
       - name: Upload LaTeX documents
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Examples
           path: "${{ env.repo_dir }}/build/*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Convert to PDF to PNG
         run: |
+          sudo apt-get update
           sudo apt-get -y install poppler-utils
           echo "running pdf to ppm..."
           pdftoppm -png -rx 300 -ry 300 "${{ env.repo_dir }}/example/${{ env.example_file }}.pdf" "${{ env.repo_dir }}/example/example"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Convert to PDF to PNG
         run: |
-          sudo apt-get -y poppler-utils
+          sudo apt-get -y install poppler-utils
           echo "running pdf to ppm..."
           pdftoppm -png -rx 300 -ry 300 "${{ env.repo_dir }}/example/${{ env.example_file }}.pdf" "${{ env.repo_dir }}/example/example"
           ls -la "${{ env.repo_dir }}/example/"
@@ -38,7 +38,7 @@ jobs:
       - name: Crop Images to content
         run: |
           cd "${{ env.repo_dir }}"
-          sudo apt-get -y imagemagick
+          sudo apt-get -y install imagemagick
           convert "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
           convert "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Convert to PDF to PNG
         run: |
-          sudo apt install poppler-utils
+          sudo apt-get -y poppler-utils
           echo "running pdf to ppm..."
           pdftoppm -png -rx 300 -ry 300 "${{ env.repo_dir }}/example/${{ env.example_file }}.pdf" "${{ env.repo_dir }}/example/example"
           ls -la "${{ env.repo_dir }}/example/"
@@ -38,7 +38,7 @@ jobs:
       - name: Crop Images to content
         run: |
           cd "${{ env.repo_dir }}"
-          sudo apt install imagemagick
+          sudo apt-get -y imagemagick
           convert "example/simple.png" -trim -bordercolor white -border 50 "example/simple.png"
           convert "example/example.png" -trim -bordercolor white -border 50 "example/example.png"
 


### PR DESCRIPTION
> Hi, it's me again, sorry I just noticed that the CI was outdated, so I might as well update to the newest versions here and there. I hope you don't mind 🙂.

# Changes:
- Update from deprecated checkout version (`@v2` -> `@v4`)
- Use newer actions wherever possible
- Use `apt-get` instead of `apt` in the command line
- Fetching `imagemagick` failed, the mirrors had to be updated with `apt-get update`